### PR TITLE
fix path to media files; let nginx serve them

### DIFF
--- a/config/nginx/mydjango.conf
+++ b/config/nginx/mydjango.conf
@@ -10,6 +10,11 @@ server {
         alias /src/static/; 
     }
 
+    location /media/ {
+        autoindex on;
+        alias /src/media/;
+    }
+
     location / {
         proxy_pass http://web/;
     }

--- a/src/mydjango/settings.py
+++ b/src/mydjango/settings.py
@@ -129,7 +129,7 @@ CELERY_BROKER_URL = 'redis://redis:6379/0'
 CELERY_RESULT_BACKEND = 'redis://redis:6379/0'
 
 STATIC_ROOT = './static/'
-MEDIA_ROOT = '/media/'
+MEDIA_ROOT = './media/'
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
MEDIA_ROOT = '/media/'  is non-optimal because is it the usual place for linux mounts, so move it to the project folder. The nginx config part is same as for static.